### PR TITLE
👷 ci: GitHub Actions で lint / typecheck / test / build を実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Lint / Typecheck / Test / Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint (oxlint)
+        run: pnpm lint
+
+      - name: Format check (oxfmt)
+        run: pnpm format:check
+
+      - name: Astro check (types + content schema)
+        run: pnpm astro check
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.33.2",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
@@ -38,5 +42,13 @@
     "typescript": "^5.6.0",
     "vitest": "^3.0.8",
     "wrangler": "^4.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "lefthook",
+      "sharp",
+      "workerd"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を新規追加。`pull_request` と `develop` / `main` への `push` をトリガに `pnpm lint` (oxlint) / `pnpm format:check` (oxfmt) / `pnpm astro check` / `pnpm test` / `pnpm build` を1ジョブで実行
- Node 24.15.0 / pnpm 10.33.2 を pin。`packageManager` フィールドで `pnpm/action-setup` の自動検出に揃え、`engines.node` に `>=22` を明示
- pnpm 10 既定でビルドスクリプトが無効化されるため、`sharp` / `workerd` / `esbuild` / `lefthook` を `pnpm.onlyBuiltDependencies` で許可
- `concurrency` で同一 ref の旧ランをキャンセル

Closes #6

## Test plan
- [ ] 本 PR 上で `verify` ジョブが起動 → 全ステップ成功
- [ ] 別ブランチで意図的に lint / format / 型 / test を破って push → 該当ステップが赤くなることを確認
- [ ] develop マージ後、direct push にも反応することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)