### PR TITLE
🔧 chore: package.json のバージョン固定化

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 side-effects-cache=false
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -21,27 +21,27 @@
     "deploy": "pnpm build && wrangler deploy"
   },
   "dependencies": {
-    "@astrojs/react": "^4.2.0",
-    "@astrojs/rss": "^4.0.10",
-    "@astrojs/sitemap": "^3.2.1",
-    "astro": "^5.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "rehype-autolink-headings": "^7.1.0",
-    "rehype-slug": "^6.0.0"
+    "@astrojs/react": "4.4.2",
+    "@astrojs/rss": "4.0.18",
+    "@astrojs/sitemap": "3.7.2",
+    "astro": "5.18.1",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "rehype-autolink-headings": "7.1.0",
+    "rehype-slug": "6.0.0"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.9.8",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "astro-eslint-parser": "^1.4.0",
-    "eslint-plugin-astro": "^1.7.0",
-    "lefthook": "^1.11.3",
-    "oxfmt": "^0.46.0",
-    "oxlint": "^1.61.0",
-    "typescript": "^5.6.0",
-    "vitest": "^3.0.8",
-    "wrangler": "^4.0.0"
+    "@astrojs/check": "0.9.8",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "astro-eslint-parser": "1.4.0",
+    "eslint-plugin-astro": "1.7.0",
+    "lefthook": "1.13.6",
+    "oxfmt": "0.46.0",
+    "oxlint": "1.61.0",
+    "typescript": "5.9.3",
+    "vitest": "3.2.4",
+    "wrangler": "4.85.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,62 +9,62 @@ importers:
   .:
     dependencies:
       '@astrojs/react':
-        specifier: ^4.2.0
+        specifier: 4.4.2
         version: 4.4.2(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)
       '@astrojs/rss':
-        specifier: ^4.0.10
+        specifier: 4.0.18
         version: 4.0.18
       '@astrojs/sitemap':
-        specifier: ^3.2.1
+        specifier: 3.7.2
         version: 3.7.2
       astro:
-        specifier: ^5.0.0
+        specifier: 5.18.1
         version: 5.18.1(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
       react:
-        specifier: ^19.0.0
+        specifier: 19.2.5
         version: 19.2.5
       react-dom:
-        specifier: ^19.0.0
+        specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
       rehype-autolink-headings:
-        specifier: ^7.1.0
+        specifier: 7.1.0
         version: 7.1.0
       rehype-slug:
-        specifier: ^6.0.0
+        specifier: 6.0.0
         version: 6.0.0
     devDependencies:
       '@astrojs/check':
-        specifier: ^0.9.8
+        specifier: 0.9.8
         version: 0.9.8(prettier@3.8.3)(typescript@5.9.3)
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 19.2.14
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       astro-eslint-parser:
-        specifier: ^1.4.0
+        specifier: 1.4.0
         version: 1.4.0
       eslint-plugin-astro:
-        specifier: ^1.7.0
+        specifier: 1.7.0
         version: 1.7.0(eslint@10.2.1)
       lefthook:
-        specifier: ^1.11.3
+        specifier: 1.13.6
         version: 1.13.6
       oxfmt:
-        specifier: ^0.46.0
+        specifier: 0.46.0
         version: 0.46.0
       oxlint:
-        specifier: ^1.61.0
+        specifier: 1.61.0
         version: 1.61.0
       typescript:
-        specifier: ^5.6.0
+        specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.8
+        specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(yaml@2.8.3)
       wrangler:
-        specifier: ^4.0.0
+        specifier: 4.85.0
         version: 4.85.0
 
 packages:


### PR DESCRIPTION
## Summary
- `package.json` の依存パッケージ指定から `^` を外し、現状のロックファイル解決済みバージョンに固定
- `.npmrc` に `save-exact=true` を追加し、以後 `pnpm add` でも自動的に固定化

## なぜ
キャレット指定だと環境間 / 時間経過で minor / patch が暗黙的に変動し、再現性のあるビルドが難しい。完全固定にすれば lockfile + package.json が真実の唯一の源になる。

## 範囲外（別 issue で対応）
今回は固定化のみ。以下のメジャーバージョン更新は破壊的変更を含むため、それぞれ個別 issue / PR で検証する:
- @astrojs/react 4 → 5
- astro 5 → 6
- lefthook 1 → 2
- typescript 5 → 6
- vitest 3 → 4

Closes #60

## Test plan
- [x] `pnpm install`（ロックファイル変更は specifier のみ）
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm astro check`（0 errors / 0 warnings）
- [x] `pnpm test`（6 tests passed）
- [x] `pnpm build`（18 pages built）

🤖 Generated with [Claude Code](https://claude.com/claude-code)