### PR TITLE
fix: Renovate コミットメッセージの v 重複を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "commitMessagePrefix": "⬆️ chore:",
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
-  "commitMessageExtra": "を v{{newVersion}} にアップデート",
+  "commitMessageExtra": "を {{newVersion}} にアップデート",
   "vulnerabilityAlerts": {
     "enabled": true,
     "schedule": []


### PR DESCRIPTION
## Summary
Renovate が出す PR タイトルが `⬆️ chore: Node.js を vv24.15.0 にアップデート` のように **`vv` で重複** してしまう問題の修正。

## 原因
`renovate.json` の `commitMessageExtra` で `を v{{newVersion}} にアップデート` と書いていたが、Node.js や github-actions のように `{{newVersion}}` 自体が `v24.15.0` のように `v` プレフィックスを含むパッケージで `v` が二重になっていた。

例 (修正前):
- #73 \`⬆️ chore: Node.js を vv22.22.2 にアップデート\`
- #74 \`⬆️ chore: github-actions を vv6.0.2 にアップデート\`
- #75 \`⬆️ chore: Node.js を vv24.15.0 にアップデート\`

## 修正
`commitMessageExtra` から `v` を削除し `を {{newVersion}} にアップデート` に変更。

修正後の出力:
- Node/Actions 系: \`⬆️ chore: Node.js を v24.15.0 にアップデート\` (`v` 込み)
- npm パッケージ: \`⬆️ chore: typescript を 6.0.4 にアップデート\` (`v` なし)

混在は残るが、二重 `v` よりは見栄えが良い。完全な統一は Renovate のテンプレ制約上難しい (`{{newVersion}}` の挙動が dependency の datasource に依存する)。

## Test plan
- [x] `pnpm dlx --package=renovate -- renovate-config-validator renovate.json` で構文検証 OK
- [ ] CI (lint / format / astro check / test / build) がグリーン
- [ ] マージ後、PR #75 を Renovate に rebase trigger して新タイトル `Node.js を v24.15.0 にアップデート` になることを確認

## 関連
- 設計書: \`docs/superpowers/specs/2026-04-26-renovate-setup-design.md\` の「未確定事項」で commitMessage* テンプレを実機出力で微調整するとしていた事項の対応
- 既にマージ済みの #73 / #74 のタイトルは過去ログとして残るが、新規 PR からは正常化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #58